### PR TITLE
修复UglifyJs会报错的问题

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var qrcode = require('./qrcode');
 var svg2url = require('./svg2url');
 
 module.exports = {
-  barcode,
-  qrcode,
-  svg2url,
+  barcode: barcode,
+  qrcode: qrcode,
+  svg2url: svg2url
 };


### PR DESCRIPTION
由于Webpack未对Node_modules里的包进行编译，所以在生成的es5 js文件里出现了es6的语法，导致UglifyJs报错。